### PR TITLE
#11116 - [JAVA][RestTemplate] URL encode

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -511,7 +511,7 @@ public class ApiClient {
             builder.queryParams(queryParams);
         }
         
-        final BodyBuilder requestBuilder = RequestEntity.method(method, builder.build().toUri());
+        final BodyBuilder requestBuilder = RequestEntity.method(method, builder.build().encode().toUri());
         if(accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }


### PR DESCRIPTION
Use UriComonentsBuilder's encode() method to properly encode the query parameters

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

